### PR TITLE
Implemented a way to use hyperref/fix TOC entries

### DIFF
--- a/umthesis.cls
+++ b/umthesis.cls
@@ -125,7 +125,7 @@
 %% Package loading
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \LoadClass[\@mysize]{report}[1996/01/02]
-\usepackage{textcase}
+\RequirePackage{textcase}
 \RequirePackage{etoolbox}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
I've implemented a way to use hyperref with the class.  At least, it works for me with an extremely basic paper.  It requires etoolbox, which I think is reasonable.  This also makes the TOC entries all caps again, like they're supposed to be.  I'm not sure if anybody else experienced this, but without these changes (or uncommenting the original redefinition of \@chapter) my TOC chapter entries were lowercase and the "CHAPTER" text didn't appear above them.
