### PR TITLE
Renaming umthesis -> umassthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**umthesis** is a LaTeX2e class file for preparing documents in the required
+**umassthesis** is a LaTeX2e class file for preparing documents in the required
 form for submission to the University of Massachusetts Graduate School. It can
 be used for doctoral dissertations or for dissertation proposals. It is based
 on the LaTeX2e report class and accepts all of the options of that class. It

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-NAME=umthesis
+NAME=umassthesis
 WHEREAMI=`cd $(dirname $0) && pwd -P`
 
 TEXVAR=${TEXMFVAR:-$(texconfig conf | grep TEXMFVAR | sed -e 's,.*=,,')}

--- a/umassthesis.bst
+++ b/umassthesis.bst
@@ -5,6 +5,7 @@
 %    History
 %     Jul 92   (Corbett) Copied ACM bst file and removed \sc from names
 %     Aug 97   (Ridgway) Renamed umthesis.bst
+%     Jan 15   (Carey) Renamed umassthesis.bst
 
 ENTRY
   { address

--- a/umassthesis.cls
+++ b/umassthesis.cls
@@ -80,7 +80,7 @@
 %% Identification part
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{umthesis}[2014/04/16 v1.26
+\ProvidesClass{umassthesis}[2014/04/16 v1.26
                          U.Mass. dissertation class]
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -103,13 +103,13 @@
 \DeclareOption{doublespace}{\double@spacetrue}
 \DeclareOption{condensed}{\condensed@frontmattertrue\double@spacefalse}
 \DeclareOption{uncondensed}{\condensed@frontmatterfalse}
-\DeclareOption{proposal}{\def\umthesis@typename{A Dissertation Outline}\@proposaltrue}
-\DeclareOption{dissertation}{\def\umthesis@typename{A Dissertation}}
-\DeclareOption{thesis}{\def\umthesis@typename{A Thesis}%
+\DeclareOption{proposal}{\def\umassthesis@typename{A Dissertation Outline}\@proposaltrue}
+\DeclareOption{dissertation}{\def\umassthesis@typename{A Dissertation}}
+\DeclareOption{thesis}{\def\umassthesis@typename{A Thesis}%
   \renewcommand{\@degree}{Master of Science}%
   \renewcommand{\@degreeabbrv}{M.S.}}
-\DeclareOption{nolisthyphenation}{\def\umthesis@listhyphenpenalty{10000}}
-\DeclareOption{allowlisthyphenation}{\def\umthesis@listhyphenpenalty{50}}
+\DeclareOption{nolisthyphenation}{\def\umassthesis@listhyphenpenalty{10000}}
+\DeclareOption{allowlisthyphenation}{\def\umassthesis@listhyphenpenalty{50}}
 \DeclareOption{nicerdraft}{\nicer@drafttrue}
 \DeclareOption{nonicerdraft}{\nicer@draftfalse}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{report}}
@@ -401,7 +401,7 @@
         \@mkboth{%
            \MakeTextUppercase\contentsname}{\MakeTextUppercase\contentsname}}%
     {\hfill \textbf{Page}\par}%
-    {\hyphenpenalty=\umthesis@listhyphenpenalty\@starttoc{toc}}%
+    {\hyphenpenalty=\umassthesis@listhyphenpenalty\@starttoc{toc}}%
     \if@restonecol\twocolumn\fi
     }
 
@@ -417,8 +417,8 @@
 
 \renewcommand{\@dotsep}{2}
 
-\newlength{\umthesis@contentshangindent}
-\setlength{\umthesis@contentshangindent}{1.55em}
+\newlength{\umassthesis@contentshangindent}
+\setlength{\umassthesis@contentshangindent}{1.55em}
 
 \renewcommand{\@dottedtocline}[5]{%
   \ifnum #1>\c@tocdepth \else
@@ -434,7 +434,7 @@
      \leavevmode
      \@tempdima #3\relax
      \advance\leftskip \@tempdima \null\nobreak\hskip -\leftskip
-     \hangindent\umthesis@contentshangindent
+     \hangindent\umassthesis@contentshangindent
      {#4}\nobreak%
      \leaders\hbox{$\m@th\mkern \@dotsep mu \hbox{.}\mkern \@dotsep mu$}%
              \hskip3em plus1fill\relax%
@@ -513,7 +513,7 @@
       \@mkboth{\MakeTextUppercase\listfigurename}%
               {\MakeTextUppercase\listfigurename}}%
     {\normalsize\parindent\z@\textbf{Figure \hfill Page}\par}%
-    {\hyphenpenalty=\umthesis@listhyphenpenalty\@starttoc{lof}}%
+    {\hyphenpenalty=\umassthesis@listhyphenpenalty\@starttoc{lof}}%
     \if@restonecol\twocolumn\fi
     }
 \fi
@@ -537,14 +537,14 @@
       \@mkboth{%
           \MakeTextUppercase\listtablename}{\MakeTextUppercase\listtablename}}%
     {\normalsize\parindent\z@\textbf{Table \hfill Page}\par}%
-    {\hyphenpenalty=\umthesis@listhyphenpenalty\@starttoc{lot}}%
+    {\hyphenpenalty=\umassthesis@listhyphenpenalty\@starttoc{lot}}%
     \if@restonecol\twocolumn\fi
     }
 \fi
 \let\l@table\l@figure
 
-\let\umthesis@base@starttoc\@starttoc
-\renewcommand{\@starttoc}{\tolerance10000\umthesis@base@starttoc}
+\let\umassthesis@base@starttoc\@starttoc
+\renewcommand{\@starttoc}{\tolerance10000\umassthesis@base@starttoc}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -619,7 +619,7 @@
 % To change Department Chair to Chair, call like this:
 % \departmentchair[Chair]{Jane Doe}.
 \newcommand{\departmentchair}[2][Department Chair]{
-  \gdef\umthesis@chairtitle{#1}
+  \gdef\umassthesis@chairtitle{#1}
   \gdef\@departmentchair{#2}
   }
 \def\departmentname#1{\gdef\@departmentname{#1}}
@@ -757,15 +757,15 @@
 %% Fix footnotes -- double spacing between footnotes, single spacing within
 %%     footnotes is what is required.
 
-\newlength{\umthesis@basefootnotesep}
-\newlength{\umthesis@baseskipfootins}
+\newlength{\umassthesis@basefootnotesep}
+\newlength{\umassthesis@baseskipfootins}
 
-\setlength{\umthesis@basefootnotesep}{\footnotesep}
-\setlength{\umthesis@baseskipfootins}{\skip\footins}
+\setlength{\umassthesis@basefootnotesep}{\footnotesep}
+\setlength{\umassthesis@baseskipfootins}{\skip\footins}
 
 \ifdouble@space
-  \setlength{\footnotesep}{2\umthesis@basefootnotesep}
-  \setlength{\skip\footins}{2\umthesis@baseskipfootins}
+  \setlength{\footnotesep}{2\umassthesis@basefootnotesep}
+  \setlength{\skip\footins}{2\umassthesis@baseskipfootins}
 \fi
 
 \pretocmd{\@footnotetext}{\linespread{1}\selectfont}%

--- a/umthcfm.clo
+++ b/umthcfm.clo
@@ -9,7 +9,7 @@
     \pagenumbering{roman}
     \null
     \textbf{\uppercase\expandafter{\@title}} \par % Title must be all caps.
-    \umthesis@typename\ Presented \par
+    \umassthesis@typename\ Presented \par
     by \par
     \uppercase\expandafter{\@author} \par
     Submitted to the Graduate School of the \par
@@ -61,7 +61,7 @@
     \fi
     \par
     Department Chair will be listed as: \par
-    \@departmentchair, \umthesis@chairtitle \par
+    \@departmentchair, \umassthesis@chairtitle \par
   \end{center}
   }
 

--- a/umthsmpl.tex
+++ b/umthsmpl.tex
@@ -84,10 +84,10 @@
 %%                    drafts -- has no effect when doublespace is in effect
 %%     nonicerdraft -- the default, leaves things in draft as they will be in
 %%                     the final version
-%% umthesis changes the default font size to 12pt, but you may specify 10pt or
+%% umassthesis changes the default font size to 12pt, but you may specify 10pt or
 %%   11pt in the options.
-\documentclass{umthesis}          % for Ph.D. dissertation or proposal
-% \documentclass[thesis]{umthesis}  % for Master's thesis
+\documentclass{umassthesis}          % for Ph.D. dissertation or proposal
+% \documentclass[thesis]{umassthesis}  % for Master's thesis
 
 %%
 %% If you have enough figures or tables that you run out of space for their
@@ -491,7 +491,7 @@ erat.
 %%
 %% A bibliography is required.
 \interlinepenalty=10000  % prevent split bibliography entries
-\bibliographystyle{umthesis}
+\bibliographystyle{umassthesis}
 \bibliography{umthsmpl}
 \end{document}
 

--- a/umthstd.clo
+++ b/umthstd.clo
@@ -13,7 +13,7 @@
       \textbf{\uppercase\expandafter{\@title}} \par
       \vfill                      % Vertical space after title.
       \doublespacenormalsize
-      \umthesis@typename\ Presented \par
+      \umassthesis@typename\ Presented \par
       by \par
       \uppercase\expandafter{\@author}
       \vfill
@@ -59,7 +59,7 @@
     \textbf{\uppercase\expandafter{\@title}} \par
     \vfill
     \doublespacenormalsize
-    \umthesis@typename\ Presented \par
+    \umassthesis@typename\ Presented \par
     by \par
     \uppercase\expandafter{\@author} \par
   \end{center}
@@ -114,7 +114,7 @@
   \begin{flushright}
     \normalsize
     \rule{0.55\textwidth}{0.5pt} \par
-    \parbox[t]{\lenguide}{\@departmentchair, \umthesis@chairtitle \par
+    \parbox[t]{\lenguide}{\@departmentchair, \umassthesis@chairtitle \par
       \@departmentname}
   \end{flushright}
   }


### PR DESCRIPTION
Addresses issue #22, by renaming `umthesis.cls` and `umthesis.bst`.

I left the rest of the `umth*` files with their original names, because AFAICT those names aren't public.

Before I merge this, could someone verify it on their end?