### PR TITLE
Silence bookmarks warning for Appendix and BackMatter

### DIFF
--- a/umassthesis.cls
+++ b/umassthesis.cls
@@ -802,3 +802,5 @@
 % silence hyperref warning about bookmark level
 \providecommand*{\toclevel@FrontMatter}{0}
 \providecommand*{\toclevel@Chapter}{0}
+\providecommand*{\toclevel@Appendix}{0}
+\providecommand*{\toclevel@BackMatter}{0}


### PR DESCRIPTION
We are already doing this for FrontMatter and Chapter. Without this, hyperref still threw warnings for me.